### PR TITLE
feat: add snowflake and trick-or-trade stamps

### DIFF
--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -47,8 +47,10 @@ interface variant_detailed {
 	 * - pokemon-center: a card that is stamped with the Pokémon Center logo
 	 * - set-promo: a card that is stamped with the set logo
 	 * - staff: a card that is stamped with the staff text
+	 * - snowflake: a card that is stamped with a snowflake, available in the yearly advent calendar
+	 * - trick-or-trade: a card that is stamped with a pikachu-pumpkin, available in the yearly halloween/trick-or-trade boosters
 	 */
-	stamp?: Array<'1st edition' | 'w-promo' | 'pre-release' | 'pokemon-center' | 'set-logo' | 'staff'>
+	stamp?: Array<'1st edition' | 'w-promo' | 'pre-release' | 'pokemon-center' | 'set-logo' | 'staff' | 'snowflake' | 'trick-or-trade'>
 	/**
 	 * for the holo & reverse, **optional** indicate which foil is used on the card
 	 */


### PR DESCRIPTION
Adds snowflake and trick-or-trade stamp types
<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->
